### PR TITLE
Add simple CI config based on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: hdn-drv
+on:
+  push:
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+
+    - name: Setup Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.14
+
+    - name: Check gofmt
+      run: test -z "$(gofmt -s -d .)"
+
+    - name: Run go vet
+      run: go vet ./...
+
+    - name: Make sure that go.mod has already been tidied
+      run: go mod tidy && git diff --no-patch --exit-code
+
+    # @todo: uncomment below once there are some tests
+
+    # - name: Run tests
+    #   run: go test -covermode=count -coverprofile=profile.cov ./...
+
+    # - name: Send coverage
+    #   env:
+    #     COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    #   run: |
+    #     GO111MODULE=off go get github.com/mattn/goveralls
+    #     $(go env GOPATH)/bin/goveralls -coverprofile=profile.cov -service=github

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # hdn_drv
+![hdn-drv](https://github.com/paddlesteamer/hdn-drv/workflows/hdn-drv/badge.svg?branch=master)
+
 Privacy wrapper for cloud storage(s)


### PR DESCRIPTION
Closes #5 

Build failure caused by `gofmt` should be fixed once https://github.com/paddlesteamer/hdn-drv/pull/4 gets merged.