### PR TITLE
Simplify manager initialization

### DIFF
--- a/cmd/hdn-drv/main.go
+++ b/cmd/hdn-drv/main.go
@@ -5,25 +5,35 @@ import (
 	"log"
 	"os"
 
+	"github.com/paddlesteamer/hdn-drv/internal/common"
 	"github.com/paddlesteamer/hdn-drv/internal/config"
+	"github.com/paddlesteamer/hdn-drv/internal/drive"
 	"github.com/paddlesteamer/hdn-drv/internal/fs"
 	"github.com/paddlesteamer/hdn-drv/internal/manager"
 	"github.com/vgough/go-fuse-c/fuse"
 )
 
 func main() {
-	conf, err := config.ParseConfig("config.json")
+	cfg, err := config.ParseConfig("config.json")
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	//@TODO: check if mount point exists, create directory if necessary
-	fmt.Printf(
-		"mount point: %s\n",
-		conf.MountPoint,
-	)
+	// @TODO: check if mount point exists, create directory if necessary
+	fmt.Printf("mount point: %s\n", cfg.MountPoint)
 
-	m, err := manager.NewManager(conf)
+	drives := collectDrives(cfg)
+	url, err := common.ParseURL(cfg.DatabaseFile)
+	if err != nil {
+		log.Fatalf("could not parse DB file URL: %v", err)
+	}
+
+	idx, err := findMatchingDriveIdx(url, drives)
+	if err != nil {
+		log.Fatalf("could not match DB file to any of the available drives: %v", err)
+	}
+
+	m, err := manager.NewManager(cfg, drives, idx)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -31,5 +41,29 @@ func main() {
 
 	fs := fs.NewHdnDrvFs(m)
 
-	fuse.MountAndRun([]string{os.Args[0], conf.MountPoint}, fs)
+	fuse.MountAndRun([]string{os.Args[0], cfg.MountPoint}, fs)
+}
+
+// collectDrives returns a slice of clients for each enabled drive.
+func collectDrives(cfg config.Cfg) []drive.Drive {
+	drives := []drive.Drive{}
+	if cfg.Dropbox != nil {
+		dbx := drive.NewDropboxClient(cfg.Dropbox)
+		drives = append(drives, dbx)
+	}
+
+	// @TODO: add GDrive
+
+	return drives
+}
+
+// findMatchingDrive returns the drive from the given list that matches the DB file scheme.
+func findMatchingDriveIdx(url *common.FileURL, drives []drive.Drive) (idx int, err error) {
+	for i, d := range drives {
+		if d.GetProviderName() == url.Scheme {
+			return i, nil
+		}
+	}
+
+	return -1, fmt.Errorf("could not find a drive matching database file scheme")
 }

--- a/cmd/hdn-drv/main.go
+++ b/cmd/hdn-drv/main.go
@@ -88,20 +88,20 @@ func findMatchingDriveIdx(url *common.FileURL, drives []drive.Drive) (idx int, e
 
 func initAndUploadDB(drv *drive.Drive, dbPath, dbExtPath string, cipher *crypto.Crypto) error {
 	if err := sqlite.InitDB(dbPath); err != nil {
-		return fmt.Errorf("couldn't initialize db: %v", err)
+		return fmt.Errorf("could not initialize DB: %v", err)
 	}
 
 	dbFile, err := os.Open(dbPath)
 	if err != nil {
 		os.Remove(dbPath)
-		return fmt.Errorf("couldn't open intitialized db: %v", err)
+		return fmt.Errorf("could not open intitialized DB: %v", err)
 	}
 	defer dbFile.Close()
 
 	err = (*drv).PutFile(dbExtPath, cipher.NewEncryptReader(dbFile))
 	if err != nil {
 		os.Remove(dbPath)
-		return fmt.Errorf("couldn't upload initialized db: %v", err)
+		return fmt.Errorf("could not upload initialized DB: %v", err)
 	}
 
 	return nil
@@ -112,14 +112,17 @@ func initOrImportDB(drv drive.Drive, file *os.File, extPath string, cipher *cryp
 
 	if err == drive.ErrNotFound {
 		initAndUploadDB(&drv, file.Name(), extPath, cipher)
+		return nil
 	} else if err != nil {
-		log.Fatalf("couldn't get file: %v", err)
+		return fmt.Errorf("could not get file: %v", err)
 	} else {
 		defer reader.Close()
 		_, err := io.Copy(file, cipher.NewDecryptReader(reader))
 		if err != nil {
 			os.Remove(file.Name())
-			log.Fatalf("couldn't copy contents of db to local file: %v", err)
+			return fmt.Errorf("could not copy contents of DB to local file: %v", err)
 		}
 	}
+
+	return nil
 }

--- a/cmd/hdn-drv/main.go
+++ b/cmd/hdn-drv/main.go
@@ -2,14 +2,17 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"os"
 
 	"github.com/paddlesteamer/hdn-drv/internal/common"
 	"github.com/paddlesteamer/hdn-drv/internal/config"
+	"github.com/paddlesteamer/hdn-drv/internal/crypto"
 	"github.com/paddlesteamer/hdn-drv/internal/drive"
 	"github.com/paddlesteamer/hdn-drv/internal/fs"
 	"github.com/paddlesteamer/hdn-drv/internal/manager"
+	"github.com/paddlesteamer/hdn-drv/internal/sqlite"
 	"github.com/vgough/go-fuse-c/fuse"
 )
 
@@ -33,14 +36,29 @@ func main() {
 		log.Fatalf("could not match DB file to any of the available drives: %v", err)
 	}
 
-	m, err := manager.NewManager(cfg, url, drives, drives[idx])
+	file, err := common.NewTempDBFile()
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("could not create DB file: %v", err)
 	}
-	defer m.Close()
+	defer file.Close()
+
+	cipher := crypto.NewCrypto(cfg.EncryptionKey)
+	if err := initOrImportDB(drives[idx], file, url.Path, cipher); err != nil {
+		log.Fatalf("could not initialize or import an existing DB file: %v", err)
+	}
+
+	hash, err := drives[idx].ComputeHash(file.Name())
+	if err != nil {
+		os.Remove(file.Name())
+		log.Fatalf("could not compute hash: %v", err)
+	}
+
+	db := manager.NewDB(file.Name(), url.Path, hash, drives[idx])
+	defer db.Close()
+
+	m := manager.NewManager(drives, db, cipher, cfg.EncryptionKey)
 
 	fs := fs.NewHdnDrvFs(m)
-
 	fuse.MountAndRun([]string{os.Args[0], cfg.MountPoint}, fs)
 }
 
@@ -48,8 +66,8 @@ func main() {
 func collectDrives(cfg config.Cfg) []drive.Drive {
 	drives := []drive.Drive{}
 	if cfg.Dropbox != nil {
-		dbx := drive.NewDropboxClient(cfg.Dropbox)
-		drives = append(drives, dbx)
+		dbox := drive.NewDropboxClient(cfg.Dropbox)
+		drives = append(drives, dbox)
 	}
 
 	// @TODO: add GDrive
@@ -66,4 +84,42 @@ func findMatchingDriveIdx(url *common.FileURL, drives []drive.Drive) (idx int, e
 	}
 
 	return -1, fmt.Errorf("could not find a drive matching database file scheme")
+}
+
+func initAndUploadDB(drv *drive.Drive, dbPath, dbExtPath string, cipher *crypto.Crypto) error {
+	if err := sqlite.InitDB(dbPath); err != nil {
+		return fmt.Errorf("couldn't initialize db: %v", err)
+	}
+
+	dbFile, err := os.Open(dbPath)
+	if err != nil {
+		os.Remove(dbPath)
+		return fmt.Errorf("couldn't open intitialized db: %v", err)
+	}
+	defer dbFile.Close()
+
+	err = (*drv).PutFile(dbExtPath, cipher.NewEncryptReader(dbFile))
+	if err != nil {
+		os.Remove(dbPath)
+		return fmt.Errorf("couldn't upload initialized db: %v", err)
+	}
+
+	return nil
+}
+
+func initOrImportDB(drv drive.Drive, file *os.File, extPath string, cipher *crypto.Crypto) error {
+	_, reader, err := drv.GetFile(extPath)
+
+	if err == drive.ErrNotFound {
+		initAndUploadDB(&drv, file.Name(), extPath, cipher)
+	} else if err != nil {
+		log.Fatalf("couldn't get file: %v", err)
+	} else {
+		defer reader.Close()
+		_, err := io.Copy(file, cipher.NewDecryptReader(reader))
+		if err != nil {
+			os.Remove(file.Name())
+			log.Fatalf("couldn't copy contents of db to local file: %v", err)
+		}
+	}
 }

--- a/cmd/hdn-drv/main.go
+++ b/cmd/hdn-drv/main.go
@@ -33,7 +33,7 @@ func main() {
 		log.Fatalf("could not match DB file to any of the available drives: %v", err)
 	}
 
-	m, err := manager.NewManager(cfg, drives, idx)
+	m, err := manager.NewManager(cfg, url, drives, drives[idx])
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -28,12 +28,10 @@ func ParseURL(fileUrl string) (*FileURL, error) {
 		return nil, fmt.Errorf("couldn't parse url '%s': %v", fileUrl, err)
 	}
 
-	fu := &FileURL{
+	return &FileURL{
 		Scheme: u.Scheme,
 		Path:   fmt.Sprintf("/%s%s", u.Host, u.Path),
-	}
-
-	return fu, nil
+	}, nil
 }
 
 func GetURL(drv drive.Drive, name string) string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,27 +11,24 @@ type DropboxCredentials struct {
 	AccessToken string
 }
 
-type Configuration struct {
+type Cfg struct {
 	EncryptionKey string
 	Dropbox       *DropboxCredentials
 	DatabaseFile  string
 	MountPoint    string
 }
 
-func ParseConfig(path string) (*Configuration, error) {
+func ParseConfig(path string) (cfg Cfg, err error) {
 	f, err := os.Open(path)
 	if err != nil {
-		return nil, fmt.Errorf("unable to open configuration file: %v", err)
+		return cfg, fmt.Errorf("unable to open config file: %v", err)
 	}
 	defer f.Close()
 
 	decoder := json.NewDecoder(f)
-	conf := Configuration{}
-
-	err = decoder.Decode(&conf)
-	if err != nil {
-		return nil, fmt.Errorf("unable to parse config json: %v", err)
+	if err = decoder.Decode(&cfg); err != nil {
+		return cfg, fmt.Errorf("unable to parse config json: %v", err)
 	}
 
-	return &conf, nil
+	return cfg, nil
 }

--- a/internal/db/client.go
+++ b/internal/db/client.go
@@ -27,8 +27,7 @@ var tableSchemas = [...]string{
 	fmt.Sprintf(`INSERT INTO files(inode, name, mode, parent, type) VALUES (1, "", 493, 0, %d);`, common.DRV_FOLDER), // root folder with mode 0755
 }
 
-// InitDB initializes tables
-// Supposed to be called on the very first run
+// InitDB initializes tables. Supposed to be called on the very first run.
 func InitDB(path string) error {
 	db, err := sql.Open("sqlite3", path)
 	if err != nil {
@@ -51,7 +50,7 @@ func InitDB(path string) error {
 	return nil
 }
 
-// NewClient returns a new database connection
+// NewClient returns a new database connection.
 func NewClient(path string) (*Client, error) {
 	db, err := sql.Open("sqlite3", path)
 	if err != nil {
@@ -64,7 +63,7 @@ func NewClient(path string) (*Client, error) {
 	return c, nil
 }
 
-// Close terminates database connection
+// Close terminates database connection.
 func (c *Client) Close() {
 	c.db.Close()
 }
@@ -206,8 +205,8 @@ func (c *Client) AddDirectory(parent int64, name string, mode int) (*common.Meta
 		return nil, err
 	}
 
-	md.NLink = 2 // since it's just created, there are only '.' and '..'
-
+	// since the directory has just been created, there are only '.' and '..'
+	md.NLink = 2
 	return md, nil
 }
 
@@ -242,8 +241,8 @@ func (c *Client) CreateFile(parent int64, name string, mode int, url string) (*c
 		return nil, err
 	}
 
-	md.NLink = 1 // it's file and hardlink isn't supported
-
+	// it's file and hardlink isn't supported
+	md.NLink = 1
 	return md, nil
 }
 
@@ -293,9 +292,7 @@ func (c *Client) fillNLink(md *common.Metadata) error {
 
 func (c *Client) parseRow(row *sql.Rows) (*common.Metadata, error) {
 	md := &common.Metadata{}
-
-	err := row.Scan(&md.Inode, &md.Name, &md.URL,
-		&md.Size, &md.Mode, &md.Parent, &md.Type)
+	err := row.Scan(&md.Inode, &md.Name, &md.URL, &md.Size, &md.Mode, &md.Parent, &md.Type)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't parse row: %v", err)
 	}

--- a/internal/drive/dropbox.go
+++ b/internal/drive/dropbox.go
@@ -40,8 +40,6 @@ func (d *Dropbox) GetFile(path string) (*Metadata, io.ReadCloser, error) {
 			return nil, nil, ErrNotFound
 		}
 
-		fmt.Println(err.Error())
-
 		return nil, nil, fmt.Errorf("could not get file from dropbox %s: %v", path, err)
 	}
 

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -17,11 +17,7 @@ type HdnDrvFs struct {
 }
 
 func NewHdnDrvFs(m *manager.Manager) *HdnDrvFs {
-	filesystem := &HdnDrvFs{
-		manager: m,
-	}
-
-	return filesystem
+	return &HdnDrvFs{manager: m}
 }
 
 func (r *HdnDrvFs) StatFs(ino int64) (*fuse.StatVFS, fuse.Status) {

--- a/internal/manager/database.go
+++ b/internal/manager/database.go
@@ -1,0 +1,45 @@
+package manager
+
+import (
+	"os"
+	"sync"
+
+	"github.com/paddlesteamer/hdn-drv/internal/drive"
+)
+
+type database struct {
+	path     string
+	extPath  string
+	hash     string
+	extDrive drive.Drive
+	mux      sync.RWMutex
+}
+
+func NewDB(path, extPath, hash string, extDrive drive.Drive) *database {
+	return &database{
+		path:     path,
+		extPath:  extPath,
+		hash:     hash,
+		extDrive: extDrive,
+	}
+}
+
+func (db *database) Close() {
+	os.Remove(db.path)
+}
+
+func (db *database) wLock() {
+	db.mux.Lock()
+}
+
+func (db *database) wUnlock() {
+	db.mux.Unlock()
+}
+
+func (db *database) rLock() {
+	db.mux.RLock()
+}
+
+func (db *database) rUnlock() {
+	db.mux.RUnlock()
+}

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -55,7 +55,7 @@ func (m *Manager) Lookup(parent int64, name string) (*common.Metadata, error) {
 	m.db.rLock()
 	defer m.db.rUnlock()
 
-	db, err := sqlite.NewClient(m.db.path)
+	db, err := sqlite.NewClient()
 	if err != nil {
 		return nil, fmt.Errorf("couldn't connect to database: %v", err)
 	}
@@ -77,7 +77,7 @@ func (m *Manager) GetMetadata(inode int64) (*common.Metadata, error) {
 	m.db.rLock()
 	defer m.db.rUnlock()
 
-	db, err := sqlite.NewClient(m.db.path)
+	db, err := sqlite.NewClient()
 	if err != nil {
 		return nil, fmt.Errorf("couldn't connect to database: %v", err)
 	}
@@ -117,7 +117,7 @@ func (m *Manager) UpdateMetadataFromCache(inode int64) error {
 		return fmt.Errorf("couldn't get file stats %s: %v", path, err)
 	}
 
-	db, err := sqlite.NewClient(m.db.path)
+	db, err := sqlite.NewClient()
 	if err != nil {
 		return fmt.Errorf("couldn't connect to database: %v", err)
 	}
@@ -144,7 +144,7 @@ func (m *Manager) UpdateMetadata(md *common.Metadata) error {
 	m.db.wLock()
 	defer m.db.wUnlock()
 
-	db, err := sqlite.NewClient(m.db.path)
+	db, err := sqlite.NewClient()
 	if err != nil {
 		return fmt.Errorf("couldn't connect to database: %v", err)
 	}
@@ -164,7 +164,7 @@ func (m *Manager) GetDirectoryContent(parent int64) ([]common.Metadata, error) {
 	m.db.rLock()
 	defer m.db.rUnlock()
 
-	db, err := sqlite.NewClient(m.db.path)
+	db, err := sqlite.NewClient()
 	if err != nil {
 		return nil, fmt.Errorf("couldn't connect to database: %v", err)
 	}
@@ -195,7 +195,7 @@ func (m *Manager) RemoveDirectory(ino int64) error {
 	m.db.wLock()
 	defer m.db.wUnlock()
 
-	db, err := sqlite.NewClient(m.db.path)
+	db, err := sqlite.NewClient()
 	if err != nil {
 		return fmt.Errorf("couldn't connect to database: %v", err)
 	}
@@ -235,7 +235,7 @@ func (m *Manager) RemoveFile(md *common.Metadata) error {
 
 	go m.deleteRemoteFile(md)
 
-	db, err := sqlite.NewClient(m.db.path)
+	db, err := sqlite.NewClient()
 	if err != nil {
 		return fmt.Errorf("couldn't connect to database: %v", err)
 	}
@@ -279,7 +279,7 @@ func (m *Manager) AddDirectory(parent int64, name string, mode int) (*common.Met
 	m.db.wLock()
 	defer m.db.wUnlock()
 
-	db, err := sqlite.NewClient(m.db.path)
+	db, err := sqlite.NewClient()
 	if err != nil {
 		return nil, fmt.Errorf("couldn't connect to database: %v", err)
 	}
@@ -298,7 +298,7 @@ func (m *Manager) CreateFile(parent int64, name string, mode int) (*common.Metad
 	m.db.wLock()
 	defer m.db.wUnlock()
 
-	db, err := sqlite.NewClient(m.db.path)
+	db, err := sqlite.NewClient()
 	if err != nil {
 		return nil, fmt.Errorf("couldn't connect to database: %v", err)
 	}

--- a/internal/sqlite/client.go
+++ b/internal/sqlite/client.go
@@ -12,8 +12,10 @@ type Client struct {
 	db *sql.DB
 }
 
-var tableSchemas = [...]string{
-	`CREATE TABLE files (
+var (
+	filePath     string
+	tableSchemas = [...]string{
+		`CREATE TABLE files (
 		"inode"  INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
 		"name"   TEXT NOT NULL,
 		"url"    TEXT NOT NULL DEFAULT "",
@@ -24,8 +26,9 @@ var tableSchemas = [...]string{
 		UNIQUE("name", "parent"),
 		FOREIGN KEY("parent") REFERENCES folders("id")
 	);`,
-	fmt.Sprintf(`INSERT INTO files(inode, name, mode, parent, type) VALUES (1, "", 493, 0, %d);`, common.DRV_FOLDER), // root folder with mode 0755
-}
+		fmt.Sprintf(`INSERT INTO files(inode, name, mode, parent, type) VALUES (1, "", 493, 0, %d);`, common.DRV_FOLDER), // root folder with mode 0755
+	}
+)
 
 // InitDB initializes tables. Supposed to be called on the very first run.
 func InitDB(path string) error {
@@ -47,14 +50,15 @@ func InitDB(path string) error {
 		}
 	}
 
+	filePath = path
 	return nil
 }
 
 // NewClient returns a new database connection.
-func NewClient(path string) (*Client, error) {
-	db, err := sql.Open("sqlite3", path)
+func NewClient() (*Client, error) {
+	db, err := sql.Open("sqlite3", filePath)
 	if err != nil {
-		return nil, fmt.Errorf("could not open DB at %s: %v", path, err)
+		return nil, fmt.Errorf("could not open DB at %s: %v", filePath, err)
 	}
 
 	return &Client{db}, nil

--- a/internal/sqlite/client.go
+++ b/internal/sqlite/client.go
@@ -50,8 +50,14 @@ func InitDB(path string) error {
 		}
 	}
 
-	filePath = path
+	SetPath(path)
+
 	return nil
+}
+
+// SetPath sets database file path
+func SetPath(path string) {
+	filePath = path
 }
 
 // NewClient returns a new database connection.

--- a/internal/sqlite/client.go
+++ b/internal/sqlite/client.go
@@ -1,4 +1,4 @@
-package db
+package sqlite
 
 import (
 	"database/sql"
@@ -54,13 +54,10 @@ func InitDB(path string) error {
 func NewClient(path string) (*Client, error) {
 	db, err := sql.Open("sqlite3", path)
 	if err != nil {
-		return nil, fmt.Errorf("couldn't open db at %s: %v", path, err)
+		return nil, fmt.Errorf("could not open DB at %s: %v", path, err)
 	}
 
-	c := &Client{
-		db: db,
-	}
-	return c, nil
+	return &Client{db}, nil
 }
 
 // Close terminates database connection.
@@ -286,7 +283,8 @@ func (c *Client) fillNLink(md *common.Metadata) error {
 		return fmt.Errorf("couldn't parse row count")
 	}
 
-	md.NLink = count + 2 // don't forget '.' and '..' dirs
+	// don't forget '.' and '..' dirs
+	md.NLink = count + 2
 	return nil
 }
 


### PR DESCRIPTION
The aim of this particular PR is to simplify the initialization of `Manager`. 

Simplifying the `NewManager` function will enable us to easily test `manager.go` in the future, because it can now be initialized with fake data.

Once this gets merged, the next goal should be to extract more files from `manager.go`, similar to how `database.go` has been extracted by this PR.