### PR TITLE
Get rid of the 'common' package: Part 1

### DIFF
--- a/cmd/cloudstash/main.go
+++ b/cmd/cloudstash/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"os"
 	"os/signal"
@@ -20,10 +21,13 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 )
 
+// @todo: remove
+const DATABASE_FILE = "dropbox://cloudstash.sqlite3"
+
 func main() {
 	cfgDir, mntDir := parseFlags()
 
-	// read existing or create new configuration
+	// read existing or create new configuration file
 	cfg, err := configure(cfgDir, mntDir)
 	if err != nil {
 		log.Fatalf("configuration error: %v", err)
@@ -35,24 +39,24 @@ func main() {
 	}
 	log.Printf("mount point: %s\n", cfg.MountPoint)
 
-	url, err := common.ParseURL(common.DATABASE_FILE)
+	dbUrl, err := common.ParseURL(DATABASE_FILE)
 	if err != nil {
 		log.Fatalf("could not parse DB file URL: %v", err)
 	}
 
 	drives := collectDrives(cfg)
-	idx, err := findMatchingDriveIdx(url, drives)
+	idx, err := findMatchingDriveIdx(dbUrl, drives)
 	if err != nil {
 		log.Fatalf("could not match DB file to any of the available drives: %v", err)
 	}
 
 	cipher := crypto.NewCrypto(cfg.EncryptionKey)
-	dbPath, hash, err := initOrImportDB(drives[idx], url.Path, cipher)
+	dbPath, hash, err := initOrImportDB(drives[idx], dbUrl.Path, cipher)
 	if err != nil {
 		log.Fatalf("could not initialize or import an existing DB file: %v", err)
 	}
 
-	db := manager.NewDB(dbPath, url.Path, hash, drives[idx])
+	db := manager.NewDB(dbPath, dbUrl.Path, hash, drives[idx])
 	defer db.Close()
 
 	m := manager.NewManager(drives, db, cipher, cfg.EncryptionKey)
@@ -141,7 +145,7 @@ func initAndUploadDB(drv drive.Drive, dbPath, dbExtPath string, cipher *crypto.C
 }
 
 func initOrImportDB(drv drive.Drive, extPath string, cipher *crypto.Crypto) (string, string, error) {
-	file, err := common.NewTempDBFile()
+	file, err := ioutil.TempFile(os.TempDir(), common.DB_FILE_PREFIX)
 	if err != nil {
 		return "", "", fmt.Errorf("could not create DB file: %v", err)
 	}
@@ -149,16 +153,18 @@ func initOrImportDB(drv drive.Drive, extPath string, cipher *crypto.Crypto) (str
 
 	_, reader, err := drv.GetFile(extPath)
 
-	if err == drive.ErrNotFound {
-		file.Close() // should be closed before initialization
+	if err != nil {
+		if err == common.ErrNotFound {
+			file.Close() // should be closed before initialization
 
-		hash, err := initAndUploadDB(drv, file.Name(), extPath, cipher)
-		if err != nil {
-			return "", "", fmt.Errorf("could not initialize DB: %v", err)
+			hash, err := initAndUploadDB(drv, file.Name(), extPath, cipher)
+			if err != nil {
+				return "", "", fmt.Errorf("could not initialize DB: %v", err)
+			}
+
+			return file.Name(), hash, nil
 		}
 
-		return file.Name(), hash, nil
-	} else if err != nil {
 		return "", "", fmt.Errorf("could not get file: %v", err)
 	}
 	defer reader.Close()

--- a/cmd/cloudstash/main.go
+++ b/cmd/cloudstash/main.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/signal"
@@ -21,9 +20,6 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 )
 
-// @todo: remove
-const DATABASE_FILE = "dropbox://cloudstash.sqlite3"
-
 func main() {
 	cfgDir, mntDir := parseFlags()
 
@@ -39,7 +35,7 @@ func main() {
 	}
 	log.Printf("mount point: %s\n", cfg.MountPoint)
 
-	dbUrl, err := common.ParseURL(DATABASE_FILE)
+	dbUrl, err := common.ParseURL(common.DATABASE_FILE)
 	if err != nil {
 		log.Fatalf("could not parse DB file URL: %v", err)
 	}
@@ -149,7 +145,7 @@ func initAndUploadDB(drv drive.Drive, dbPath, dbExtPath string, cipher *crypto.C
 }
 
 func initOrImportDB(drv drive.Drive, extPath string, cipher *crypto.Crypto) (string, string, error) {
-	file, err := ioutil.TempFile(os.TempDir(), common.DB_FILE_PREFIX)
+	file, err := common.NewTempDBFile()
 	if err != nil {
 		return "", "", fmt.Errorf("could not create DB file: %v", err)
 	}

--- a/internal/common/constants.go
+++ b/internal/common/constants.go
@@ -5,9 +5,7 @@ import "github.com/paddlesteamer/go-fuse-c/fuse"
 const (
 	DRV_FILE   = fuse.S_IFREG
 	DRV_FOLDER = fuse.S_IFDIR
-)
 
-const (
-	DROPBOX_APP_KEY = "l4v6ipcr1rlwu1x"
-	DATABASE_FILE   = "dropbox://cloudstash.sqlite3" // @TODO: to be removed later
+	CACHE_FILE_PREFIX = "cloudstash-cached-"
+	DB_FILE_PREFIX    = "cloudstash-db-"
 )

--- a/internal/common/constants.go
+++ b/internal/common/constants.go
@@ -6,6 +6,11 @@ const (
 	DRV_FILE   = fuse.S_IFREG
 	DRV_FOLDER = fuse.S_IFDIR
 
-	CACHE_FILE_PREFIX = "cloudstash-cached-"
-	DB_FILE_PREFIX    = "cloudstash-db-"
+	cacheFilePrefix = "cloudstash-cached-"
+	dbFilePrefix    = "cloudstash-db-"
+)
+
+const (
+	DROPBOX_APP_KEY = "l4v6ipcr1rlwu1x"
+	DATABASE_FILE   = "dropbox://cloudstash.sqlite3" // @TODO: to be removed later
 )

--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -4,7 +4,9 @@ import (
 	"crypto/md5"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/url"
+	"os"
 	"time"
 )
 
@@ -23,6 +25,18 @@ func ParseURL(fileUrl string) (*FileURL, error) {
 		Scheme: u.Scheme,
 		Path:   fmt.Sprintf("/%s%s", u.Host, u.Path),
 	}, nil
+}
+
+func NewTempCacheFile() (*os.File, error) {
+	tmpfile, err := ioutil.TempFile(os.TempDir(), cacheFilePrefix)
+
+	return tmpfile, err
+}
+
+func NewTempDBFile() (*os.File, error) {
+	tmpfile, err := ioutil.TempFile(os.TempDir(), dbFilePrefix)
+
+	return tmpfile, err
 }
 
 func ObfuscateFileName(name string) string {

--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -4,15 +4,8 @@ import (
 	"crypto/md5"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
-	"os"
 	"time"
-)
-
-const (
-	cacheFilePrefix = "cloudstash-cached-"
-	dbFilePrefix    = "cloudstash-db-"
 )
 
 type FileURL struct {
@@ -30,18 +23,6 @@ func ParseURL(fileUrl string) (*FileURL, error) {
 		Scheme: u.Scheme,
 		Path:   fmt.Sprintf("/%s%s", u.Host, u.Path),
 	}, nil
-}
-
-func NewTempCacheFile() (*os.File, error) {
-	tmpfile, err := ioutil.TempFile(os.TempDir(), cacheFilePrefix)
-
-	return tmpfile, err
-}
-
-func NewTempDBFile() (*os.File, error) {
-	tmpfile, err := ioutil.TempFile(os.TempDir(), dbFilePrefix)
-
-	return tmpfile, err
 }
 
 func ObfuscateFileName(name string) string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/paddlesteamer/cloudstash/internal/auth"
+	"github.com/paddlesteamer/cloudstash/internal/common"
 )
 
 type DropboxCredentials struct {
@@ -24,7 +25,6 @@ const (
 	cfgFile         = "config.json"
 	cfgFolder       = "cloudstash"
 	mountFolderName = "cloudstash"
-	dropboxAppKey   = "l4v6ipcr1rlwu1x"
 )
 
 func DoesConfigExist(dir string) bool {
@@ -56,7 +56,7 @@ func ReadConfig(dir string) (*Cfg, error) {
 }
 
 func NewConfig(cfgDir, mntDir string, secret []byte) (cfg *Cfg, err error) {
-	dbxToken, err := auth.GetDropboxToken(dropboxAppKey)
+	dbxToken, err := auth.GetDropboxToken(common.DROPBOX_APP_KEY)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't get dropbox access token: %v\n", err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/paddlesteamer/cloudstash/internal/auth"
-	"github.com/paddlesteamer/cloudstash/internal/common"
 )
 
 type DropboxCredentials struct {
@@ -22,9 +21,10 @@ type Cfg struct {
 }
 
 const (
-	cfgFile         string = "config.json"
-	cfgFolder       string = "cloudstash"
-	mountFolderName string = "cloudstash"
+	cfgFile         = "config.json"
+	cfgFolder       = "cloudstash"
+	mountFolderName = "cloudstash"
+	dropboxAppKey   = "l4v6ipcr1rlwu1x"
 )
 
 func DoesConfigExist(dir string) bool {
@@ -56,7 +56,7 @@ func ReadConfig(dir string) (*Cfg, error) {
 }
 
 func NewConfig(cfgDir, mntDir string, secret []byte) (cfg *Cfg, err error) {
-	dbxToken, err := auth.GetDropboxToken(common.DROPBOX_APP_KEY)
+	dbxToken, err := auth.GetDropboxToken(dropboxAppKey)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't get dropbox access token: %v\n", err)
 	}

--- a/internal/drive/drive.go
+++ b/internal/drive/drive.go
@@ -1,23 +1,20 @@
 package drive
 
 import (
-	"errors"
 	"fmt"
 	"io"
 )
 
-var ErrNotFound = errors.New("not found")
-
 type Drive interface {
 	GetProviderName() string
-	GetFile(path string) (*Metadata, io.ReadCloser, error)
+	GetFile(path string) (*metadata, io.ReadCloser, error)
 	PutFile(path string, content io.Reader) error
-	GetFileMetadata(path string) (*Metadata, error)
+	GetFileMetadata(path string) (*metadata, error)
 	DeleteFile(path string) error
 	ComputeHash(r io.Reader, hchan chan string, echan chan error)
 }
 
-type Metadata struct {
+type metadata struct {
 	Name string
 	Size uint64
 	Hash string

--- a/internal/drive/drive.go
+++ b/internal/drive/drive.go
@@ -5,21 +5,39 @@ import (
 	"io"
 )
 
-type Drive interface {
-	GetProviderName() string
-	GetFile(path string) (*metadata, io.ReadCloser, error)
-	PutFile(path string, content io.Reader) error
-	GetFileMetadata(path string) (*metadata, error)
-	DeleteFile(path string) error
-	ComputeHash(r io.Reader, hchan chan string, echan chan error)
-}
-
-type metadata struct {
+// Metadata contains name, size (in bytes), and content hash of a remote file
+type Metadata struct {
 	Name string
 	Size uint64
 	Hash string
 }
 
+// Drive is the interface every remote drive client should implement
+type Drive interface {
+
+	// GetProviderName returns name of the drive. i.e. dropbox
+	GetProviderName() string
+
+	// GetFile returns metadata and reader of the requested remote file
+	// If file couldn't be found, it should return common.ErrNotFound
+	GetFile(path string) (*Metadata, io.ReadCloser, error)
+
+	// PutFile uploads specified file to the remote drive
+	// It overwrites if the file exists
+	PutFile(path string, content io.Reader) error
+
+	// GetFileMetadata returns metadata of the remote file
+	GetFileMetadata(path string) (*Metadata, error)
+
+	// DeleteFile removes file from the remote drive
+	DeleteFile(path string) error
+
+	// ComputeHash computes hash of file with drive's specific method
+	ComputeHash(r io.Reader, hchan chan string, echan chan error)
+}
+
+// GetURL creates URL of remote file
+// i.e. dropbox://filename.ext
 func GetURL(drv Drive, name string) string {
 	scheme := drv.GetProviderName()
 

--- a/internal/drive/dropbox.go
+++ b/internal/drive/dropbox.go
@@ -31,7 +31,7 @@ func (d *Dropbox) GetProviderName() string {
 }
 
 // @todo: add descriptive comment
-func (d *Dropbox) GetFile(path string) (*metadata, io.ReadCloser, error) {
+func (d *Dropbox) GetFile(path string) (*Metadata, io.ReadCloser, error) {
 	args := files.NewDownloadArg(path)
 	md, r, err := d.client.Download(args)
 	if err != nil {
@@ -43,7 +43,7 @@ func (d *Dropbox) GetFile(path string) (*metadata, io.ReadCloser, error) {
 		return nil, nil, fmt.Errorf("could not get file from dropbox %s: %v", path, err)
 	}
 
-	m := &metadata{
+	m := &Metadata{
 		Name: md.Name,
 		Size: md.Size,
 		Hash: md.ContentHash,
@@ -67,7 +67,7 @@ func (d *Dropbox) PutFile(path string, content io.Reader) error {
 }
 
 // GetFileMetadata gets the file metadata given the file path.
-func (d *Dropbox) GetFileMetadata(path string) (*metadata, error) {
+func (d *Dropbox) GetFileMetadata(path string) (*Metadata, error) {
 	args := &files.GetMetadataArg{
 		Path: path,
 	}
@@ -77,7 +77,7 @@ func (d *Dropbox) GetFileMetadata(path string) (*metadata, error) {
 		return nil, fmt.Errorf("unable to get metadata of dropbox file '%s': %v", path, err)
 	}
 
-	return &metadata{
+	return &Metadata{
 		Name: md.(*files.FileMetadata).Name,
 		Size: md.(*files.FileMetadata).Size,
 		Hash: md.(*files.FileMetadata).ContentHash,

--- a/internal/drive/dropbox.go
+++ b/internal/drive/dropbox.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/dropbox"
 	"github.com/dropbox/dropbox-sdk-go-unofficial/dropbox/files"
+	"github.com/paddlesteamer/cloudstash/internal/common"
 	"github.com/paddlesteamer/cloudstash/internal/config"
 )
 
@@ -30,29 +31,29 @@ func (d *Dropbox) GetProviderName() string {
 }
 
 // @todo: add descriptive comment
-func (d *Dropbox) GetFile(path string) (*Metadata, io.ReadCloser, error) {
+func (d *Dropbox) GetFile(path string) (*metadata, io.ReadCloser, error) {
 	args := files.NewDownloadArg(path)
-	metadata, r, err := d.client.Download(args)
+	md, r, err := d.client.Download(args)
 	if err != nil {
 		// no other way to distinguish not found error
 		if strings.Contains(err.Error(), "not_found") {
-			return nil, nil, ErrNotFound
+			return nil, nil, common.ErrNotFound
 		}
 
 		return nil, nil, fmt.Errorf("could not get file from dropbox %s: %v", path, err)
 	}
 
-	m := &Metadata{
-		Name: metadata.Name,
-		Size: metadata.Size,
-		Hash: metadata.ContentHash,
+	m := &metadata{
+		Name: md.Name,
+		Size: md.Size,
+		Hash: md.ContentHash,
 	}
 	return m, r, nil
 }
 
 // PutFile uploads a new file.
 func (d *Dropbox) PutFile(path string, content io.Reader) error {
-	if err := d.DeleteFile(path); err != nil && err != ErrNotFound {
+	if err := d.DeleteFile(path); err != nil && err != common.ErrNotFound {
 		return fmt.Errorf("couldn't delete file from dropbox before upload: %v", err)
 	}
 
@@ -66,20 +67,20 @@ func (d *Dropbox) PutFile(path string, content io.Reader) error {
 }
 
 // GetFileMetadata gets the file metadata given the file path.
-func (d *Dropbox) GetFileMetadata(path string) (*Metadata, error) {
+func (d *Dropbox) GetFileMetadata(path string) (*metadata, error) {
 	args := &files.GetMetadataArg{
 		Path: path,
 	}
 
-	metadata, err := d.client.GetMetadata(args)
+	md, err := d.client.GetMetadata(args)
 	if err != nil {
-		return nil, fmt.Errorf("dropbox: unable to get metadata of %v: %v", path, err)
+		return nil, fmt.Errorf("unable to get metadata of dropbox file '%s': %v", path, err)
 	}
 
-	return &Metadata{
-		Name: metadata.(*files.FileMetadata).Name,
-		Size: metadata.(*files.FileMetadata).Size,
-		Hash: metadata.(*files.FileMetadata).ContentHash,
+	return &metadata{
+		Name: md.(*files.FileMetadata).Name,
+		Size: md.(*files.FileMetadata).Size,
+		Hash: md.(*files.FileMetadata).ContentHash,
 	}, nil
 }
 
@@ -89,7 +90,7 @@ func (d *Dropbox) DeleteFile(path string) error {
 	_, err := d.client.DeleteV2(dargs) //@TODO: ignore notfound error but check other errors
 	if err != nil {
 		if strings.Contains(err.Error(), "not_found") {
-			return ErrNotFound
+			return common.ErrNotFound
 		}
 
 		return fmt.Errorf("couldn't delete file from dropbox: %v", err)

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/paddlesteamer/cloudstash/internal/common"
 	"github.com/paddlesteamer/cloudstash/internal/manager"
+	"github.com/paddlesteamer/cloudstash/internal/sqlite"
 	"github.com/paddlesteamer/go-fuse-c/fuse"
 )
 
@@ -453,7 +454,7 @@ func (fs *CloudStashFs) Rename(oparent int64, oname string, tparent int64, tname
 	return fuse.OK
 }
 
-func newInode(md *common.Metadata) *fuse.InoAttr {
+func newInode(md *sqlite.Metadata) *fuse.InoAttr {
 	inode := &fuse.InoAttr{
 		Ino:     md.Inode,
 		NLink:   md.NLink,

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -3,7 +3,6 @@ package manager
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"time"
@@ -364,7 +363,7 @@ func (m *Manager) CreateFile(parent int64, name string, mode int) (*sqlite.Metad
 
 	u := drive.GetURL(m.selectDrive(), common.ObfuscateFileName(name))
 
-	tmpfile, err := ioutil.TempFile(os.TempDir(), common.CACHE_FILE_PREFIX)
+	tmpfile, err := common.NewTempCacheFile()
 	if err != nil {
 		return nil, fmt.Errorf("couldn't create cached file: %v", err)
 	}
@@ -417,7 +416,7 @@ func (m *Manager) downloadFile(md *sqlite.Metadata) (string, error) {
 	}
 	defer reader.Close()
 
-	tmpfile, err := ioutil.TempFile(os.TempDir(), common.CACHE_FILE_PREFIX)
+	tmpfile, err := common.NewTempCacheFile()
 	if err != nil {
 		return "", fmt.Errorf("couldn't create cached file: %v", err)
 	}

--- a/internal/sqlite/client.go
+++ b/internal/sqlite/client.go
@@ -76,7 +76,7 @@ func (c *Client) Close() {
 	c.db.Close()
 }
 
-func (c *Client) Search(parent int64, name string) (*common.Metadata, error) {
+func (c *Client) Search(parent int64, name string) (*Metadata, error) {
 	query, err := c.db.Prepare("SELECT * FROM files WHERE name=? and parent=?")
 	if err != nil {
 		return nil, fmt.Errorf("couldn't prepare statement: %v", err)
@@ -95,7 +95,7 @@ func (c *Client) Search(parent int64, name string) (*common.Metadata, error) {
 	return c.parseRow(row)
 }
 
-func (c *Client) Get(inode int64) (*common.Metadata, error) {
+func (c *Client) Get(inode int64) (*Metadata, error) {
 	query, err := c.db.Prepare("SELECT * FROM files WHERE inode=?")
 	if err != nil {
 		return nil, fmt.Errorf("couldn't prepare statement: %v", err)
@@ -138,7 +138,7 @@ func (c *Client) Delete(inode int64) error {
 	return nil
 }
 
-func (c *Client) GetChildren(parent int64) ([]common.Metadata, error) {
+func (c *Client) GetChildren(parent int64) ([]Metadata, error) {
 	query, err := c.db.Prepare("SELECT * FROM files WHERE parent=?")
 	if err != nil {
 		return nil, fmt.Errorf("couldn't prepare statement: %v", err)
@@ -150,7 +150,7 @@ func (c *Client) GetChildren(parent int64) ([]common.Metadata, error) {
 	}
 	defer row.Close()
 
-	mdList := []common.Metadata{}
+	mdList := []Metadata{}
 	for row.Next() {
 		md, err := c.parseRow(row)
 		if err != nil {
@@ -182,7 +182,7 @@ func (c *Client) DeleteChildren(parent int64) error {
 	return nil
 }
 
-func (c *Client) AddDirectory(parent int64, name string, mode int) (*common.Metadata, error) {
+func (c *Client) AddDirectory(parent int64, name string, mode int) (*Metadata, error) {
 	query, err := c.db.Prepare("INSERT INTO files(name, mode, parent, type) VALUES(?, ?, ?, ?)")
 	if err != nil {
 		return nil, fmt.Errorf("couldn't prepare statement: %v", err)
@@ -218,7 +218,7 @@ func (c *Client) AddDirectory(parent int64, name string, mode int) (*common.Meta
 	return md, nil
 }
 
-func (c *Client) CreateFile(parent int64, name string, mode int, url string, hash string) (*common.Metadata, error) {
+func (c *Client) CreateFile(parent int64, name string, mode int, url string, hash string) (*Metadata, error) {
 	query, err := c.db.Prepare("INSERT INTO files(name, url, size, mode, parent, type, hash) VALUES(?, ?, ?, ?, ?, ?, ?)")
 	if err != nil {
 		return nil, fmt.Errorf("couldn't prepare statement: %v", err)
@@ -254,7 +254,7 @@ func (c *Client) CreateFile(parent int64, name string, mode int, url string, has
 	return md, nil
 }
 
-func (c *Client) Update(md *common.Metadata) error {
+func (c *Client) Update(md *Metadata) error {
 	query, err := c.db.Prepare("UPDATE files SET name=?, url=?, size=?, mode=?, parent=?, type=? WHERE inode=?")
 	if err != nil {
 		return fmt.Errorf("couldn't prepare statement: %v", err)
@@ -268,7 +268,7 @@ func (c *Client) Update(md *common.Metadata) error {
 	return nil
 }
 
-func (c *Client) fillNLink(md *common.Metadata) error {
+func (c *Client) fillNLink(md *Metadata) error {
 	if md.Type == common.DRV_FILE {
 		md.NLink = 1
 		return nil
@@ -299,8 +299,8 @@ func (c *Client) fillNLink(md *common.Metadata) error {
 	return nil
 }
 
-func (c *Client) parseRow(row *sql.Rows) (*common.Metadata, error) {
-	md := &common.Metadata{}
+func (c *Client) parseRow(row *sql.Rows) (*Metadata, error) {
+	md := &Metadata{}
 	err := row.Scan(&md.Inode, &md.Name, &md.URL, &md.Size, &md.Mode, &md.Parent, &md.Type, &md.Hash)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't parse row: %v", err)

--- a/internal/sqlite/metadata.go
+++ b/internal/sqlite/metadata.go
@@ -1,4 +1,4 @@
-package common
+package sqlite
 
 type Metadata struct {
 	Inode  int64


### PR DESCRIPTION
After this gets merged, I plan to open a second PR to completely get rid of the `common` package.

The reason I want to get rid of it is; package names like `common`, `util`, `manager` (yes, it's on my todo list 😄) do not really mean anything other than they always seem to be the go-to place to put new stuff. So they eventually end up being very fat things that contain a lot of unrelated stuff.